### PR TITLE
DVSP-22544: A team member can view details of a devspace assigned to their team - Rename and Delete options are displayed

### DIFF
--- a/wizard/control-devspace-team-shared.json
+++ b/wizard/control-devspace-team-shared.json
@@ -89,13 +89,5 @@
       "description": "",
       "command": "devspaces get-config {devspacename}"
     }]
-  }, {
-    "stepNumber": 12,
-    "stepSummary": "Rename",
-    "description": "Rename this DevSpace",
-    "commands": [{
-      "description": "",
-      "command": "devspaces rename {devspacename} [new name]"
-    }]
   }]
 }


### PR DESCRIPTION
**Jira Ticket:** [DVSP-22907](https://jira.devfactory.com/browse/DVSP-22907)
** E2E link ** https://jira.devfactory.com/browse/DVSP-18863 (Step 5 failed without this PR)

Team shared template fixed, rename option removed.

No UT as this is only template fix, no infrastructure to test.

Confirmation video: https://drive.google.com/file/d/1SsZqU2TTvig-kROHkopz4gCAYnN7YRBt/view?usp=sharing
This PR should be merged together with the fix of backend part: https://github.com/trilogy-group/devfactory-devspaces/pull/3471 

CI/CD: This is a template repository, nothing to build here. Eng.Problem created: https://jira.devfactory.com/browse/DVSP-22777