### PR TITLE
DVSP-23035: A team member should have instructions and should be allowed to create a devspace in a team they are in via the client on MacOS

### DIFF
--- a/wizard/custom-templates.json
+++ b/wizard/custom-templates.json
@@ -46,7 +46,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     },
@@ -144,7 +144,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     }

--- a/wizard/kubernetes.json
+++ b/wizard/kubernetes.json
@@ -58,7 +58,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     },
@@ -181,7 +181,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     }

--- a/wizard/private.json
+++ b/wizard/private.json
@@ -49,7 +49,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     },
@@ -156,7 +156,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     }

--- a/wizard/public.json
+++ b/wizard/public.json
@@ -49,7 +49,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     },
@@ -155,7 +155,7 @@
         "command": "devspaces create"
       }, {
         "description": "",
-        "command": "devspaces create -t [team id]"
+        "command": "devspaces create --team=[team id]"
       }],
       "actionButton": {}
     }


### PR DESCRIPTION
**Jira Ticket:** [DVSP-23035](https://jira.devfactory.com/browse/DVSP-23035)
** E2E link ** https://jira.devfactory.com/browse/DVSP-19017 (Step 4 failed without this PR)

Templates fixed to show correct command syntax.

No UT as this is only template fix, no infrastructure to test.

Confirmation video: https://drive.google.com/file/d/1EObP3jwDGB3FM_sZp8zRFRMC3nsKGxJ4/view?usp=sharing


CI/CD: This is a template repository, nothing to build here. Eng.Problem created: https://jira.devfactory.com/browse/DVSP-22777