### PR TITLE
DVSP-24206: add missing relative attribute on action buttons

### DIFF
--- a/wizard/custom-templates.json
+++ b/wizard/custom-templates.json
@@ -60,7 +60,8 @@
       "commands": [],
       "actionButton": {
         "label": "Get Client",
-        "url": "/devspaces/download"
+        "url": "/devspaces/download",
+        "relative": true
       }
     },
     {
@@ -109,7 +110,8 @@
       "commands": [],
       "actionButton": {
         "label": "Get Client",
-        "url": "/devspaces/download"
+        "url": "/devspaces/download",
+        "relative": true
       }
     },
     {


### PR DESCRIPTION
**Jira Ticket:** [DVSP-24206](https://jira.devfactory.com/browse/DVSP-24206)
**E2E link:** [DVSP-24473](https://jira.devfactory.com/browse/DVSP-24473) (Step 2 will fail without the fix)

**Fix Summary:**
add relative attribute in each action button, so button will go to correct `/devspaces/download` page.

**UTs:** N/A (changes in json file which has no test framework)
**CI/CD:** Not configured because the repo only contains templates without any executable codes.
Eng.Problem: https://jira.devfactory.com/browse/DVSP-22777